### PR TITLE
Add filtering for selective export

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,55 @@ exec(op('export_network').text)
 
 See [`example_export.json`](example_export.json) for a real-world export from a Gaussian splatting project.
 
+## Filtering
+
+The full export can be huge (24MB+ for complex projects). Use filters to export only what you need. Set them at the top of `export_network.py`:
+
+```python
+# Only export TOP and CHOP operators
+FILTER_FAMILIES = ['TOP', 'CHOP']
+
+# Only export specific operator types
+FILTER_TYPES = ['moviefilein', 'null', 'geo']
+
+# Only export operators under a specific path
+FILTER_PATH_PREFIX = '/project1/fx'
+
+# Limit recursion depth
+FILTER_MAX_DEPTH = 3
+
+# Include/exclude by operator name (fnmatch patterns)
+INCLUDE_PATTERNS = ['render*', '*_out']
+EXCLUDE_PATTERNS = ['__*', 'local*']
+```
+
+All filters are optional and combine with AND logic. Leave as `None` to disable.
+
+Container operators (COMPs) are automatically kept in the output when they have matching descendants, so the hierarchy stays readable even with aggressive filtering.
+
+### Programmatic Usage
+
+You can also call `export_network()` as a function from another script or the Textport:
+
+```python
+# In the Textport or another DAT:
+exec(op('export_network').text)
+
+# Export only TOPs under /project1, 3 levels deep
+export_network(
+    path_prefix='/project1',
+    families=['TOP'],
+    max_depth=3,
+    output_filename='tops_only.json'
+)
+```
+
 ## Configuration
 
-In `export_network.py`, you can adjust:
+Other settings in `export_network.py`:
 
-- **`max_depth`** — how deep to recurse into nested COMPs (default: 6)
-- **Root operator** — change `op('/')` to export a subtree instead of the whole project
+- **`FILTER_MAX_DEPTH`** -- how deep to recurse into nested COMPs (default: 6)
+- **Root operator** -- change `op('/')` to export a subtree instead of the whole project
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Export your TouchDesigner network to JSON so LLMs can understand your project.
 
-TD4LLMs serializes your entire TD network — operators, parameters, connections, and hierarchy — into a structured JSON file. Feed it to Claude, ChatGPT, or any LLM to get help debugging, documenting, or extending your TouchDesigner projects.
+TD4LLMs serializes your TD network -- operators, parameters, connections, and hierarchy -- into a compact format designed for LLM context windows. Feed it to Claude, ChatGPT, or any LLM to get help debugging, documenting, or extending your TouchDesigner projects.
 
 ## Why?
 
-TouchDesigner's `.toe` files are binary — LLMs can't read them. TD4LLMs bridges that gap by exporting a complete, human-readable representation of your network that gives an LLM full context about your project's structure.
+TouchDesigner's `.toe` files are binary -- LLMs can't read them. TD4LLMs bridges that gap by exporting a human-readable representation of your network. Only non-default parameters are included, so the output is small enough to paste directly into an LLM conversation.
 
 ## Quick Start
 
@@ -17,23 +17,73 @@ TouchDesigner's `.toe` files are binary — LLMs can't read them. TD4LLMs bridge
 exec(op('export_network').text)
 ```
 
-3. Find `network_export.json` in your project folder
-4. Paste the JSON into your LLM conversation for context
+3. Find `network_export.json` (or `.jsonl`) in your project folder
+4. Paste the output into your LLM conversation for context
 
 ## What Gets Exported
 
-- **Operator tree** — full hierarchy with paths, names, types, and families
-- **Parameters** — all parameter pages serialized via TDJSON (TouchDesigner's built-in serializer)
-- **Connections** — input/output wiring between operators
-- **Recursion** — descends into COMPs up to a configurable depth (default: 6 levels)
+- **Operator tree** -- full hierarchy with paths, names, types, and families
+- **Parameters** -- only non-default values (parameters you actually changed)
+- **Connections** -- input/output wiring between operators as path arrays
+- **Recursion** -- descends into COMPs up to a configurable depth (default: 6 levels)
 
-## Example
+## Output Modes
 
-See [`example_export.json`](example_export.json) for a real-world export from a Gaussian splatting project.
+Control how much detail is exported with `OUTPUT_MODE` at the top of the script:
+
+| Mode | What's included | Best for |
+|------|----------------|----------|
+| `compact` (default) | Non-default params as bare values | Day-to-day LLM use |
+| `summary` | Operator tree + connections only, no params | Architecture overview |
+| `full` | Non-default params with metadata (style, mode) | Debugging parameter issues |
+
+### Compact mode example
+
+```json
+{
+  "path": "/project1/render1",
+  "name": "render1",
+  "type": "glslmulti",
+  "family": "TOP",
+  "params": {"resolutionw": 1920, "resolutionh": 1080, "outputresolution": 9},
+  "inputs": ["/project1/noise1", "/project1/feedback1"]
+}
+```
+
+Parameters you never touched are omitted. Expressions, binds, and exports are preserved:
+
+```json
+{
+  "params": {
+    "tx": {"expr": "absTime.seconds * 0.1"},
+    "opacity": {"bind": "op('ctrl')['opacity']"},
+    "file": "/path/to/video.mov"
+  }
+}
+```
+
+### Summary mode example
+
+```json
+{"path": "/project1/render1", "type": "glslmulti", "family": "TOP", "inputs": ["/project1/noise1"]}
+```
+
+No parameters at all -- just the network graph.
+
+## Output Formats
+
+Set `OUTPUT_FORMAT` at the top of the script:
+
+| Format | Description | Output file |
+|--------|------------|-------------|
+| `json` (default) | Nested JSON tree | `network_export.json` |
+| `jsonl` | Flat JSONL, one operator per line | `network_export.jsonl` |
+
+**JSONL** is useful for very large networks -- you can grep it, load specific operators, or stream it line by line. Each line is a self-contained JSON object with the operator's `path` encoding its position in the hierarchy.
 
 ## Filtering
 
-The full export can be huge (24MB+ for complex projects). Use filters to export only what you need. Set them at the top of `export_network.py`:
+Use filters to export only what you need. Set them at the top of `export_network.py`:
 
 ```python
 # Only export TOP and CHOP operators
@@ -65,26 +115,42 @@ You can also call `export_network()` as a function from another script or the Te
 # In the Textport or another DAT:
 exec(op('export_network').text)
 
-# Export only TOPs under /project1, 3 levels deep
+# Export only TOPs under /project1, summary mode, as JSONL
 export_network(
     path_prefix='/project1',
     families=['TOP'],
     max_depth=3,
-    output_filename='tops_only.json'
+    output_mode='summary',
+    output_format='jsonl',
+    output_filename='tops_summary.jsonl'
 )
 ```
 
+## Size Comparison
+
+On a real-world Gaussian splatting project (19,377 operators):
+
+| Configuration | Size | Reduction |
+|--------------|------|-----------|
+| Original (pretty JSON, all pages) | 23.5 MB | -- |
+| Compact JSON (non-default params, minified) | ~2.9 MB | 88% |
+| Summary JSONL (tree + connections only) | ~2.4 MB | 90% |
+
+With filtering applied (e.g., only TOPs in one subtree), output typically drops to KB range.
+
 ## Configuration
 
-Other settings in `export_network.py`:
+Settings at the top of `export_network.py`:
 
+- **`OUTPUT_MODE`** -- `'compact'`, `'summary'`, or `'full'` (default: `'compact'`)
+- **`OUTPUT_FORMAT`** -- `'json'` or `'jsonl'` (default: `'json'`)
 - **`FILTER_MAX_DEPTH`** -- how deep to recurse into nested COMPs (default: 6)
 - **Root operator** -- change `op('/')` to export a subtree instead of the whole project
 
 ## Requirements
 
 - TouchDesigner (tested on 2023.x+)
-- Uses the built-in `TDJSON` module (no external dependencies)
+- No external dependencies (uses TD's built-in `Par` API directly)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TD4LLMs serializes your TD network -- operators, parameters, connections, and hi
 
 ## Why?
 
-TouchDesigner's `.toe` files are binary -- LLMs can't read them. TD4LLMs bridges that gap by exporting a human-readable representation of your network. Only non-default parameters are included, so the output is small enough to paste directly into an LLM conversation.
+TouchDesigner's `.toe` files are binary -- LLMs can't read them. TD4LLMs bridges that gap by exporting a human-readable representation of your network. Only non-default parameters are included, and system/UI boilerplate is excluded by default, so the output is small enough to paste directly into an LLM conversation.
 
 ## Quick Start
 
@@ -22,10 +22,82 @@ exec(op('export_network').text)
 
 ## What Gets Exported
 
-- **Operator tree** -- full hierarchy with paths, names, types, and families
+- **Operator tree** -- full hierarchy with paths, types, and families
 - **Parameters** -- only non-default values (parameters you actually changed)
-- **Connections** -- input/output wiring between operators as path arrays
-- **Recursion** -- descends into COMPs up to a configurable depth (default: 6 levels)
+- **Relationship graph** -- all connections as a top-level adjacency list with typed edges (input/bind/export)
+- **Templates** -- repeated operator configurations are defined once and referenced, reducing duplication
+- **Metadata** -- operator counts, subsystem breakdown, cross-subsystem connections
+
+### What Gets Excluded (by default)
+
+TD projects contain thousands of system and UI operators (`/sys`, `/ui`) that are identical across all projects. These are excluded by default since they're noise for LLM context. On a real project this typically removes 95-98% of operators. Set `EXCLUDE_SYSTEM = False` to include them.
+
+## Output Structure
+
+```json
+{
+  "_meta": {
+    "total_ops": 437,
+    "connections": 215,
+    "system_excluded": ["/sys", "/ui"],
+    "subsystems": {
+      "/project1": {"ops": 381, "types": {"TOP": 45, "CHOP": 12, ...}}
+    }
+  },
+  "graph": [
+    ["input", "/project1/noise1", "/project1/comp1", 0],
+    ["bind", "op('ctrl')['opacity']", "/project1/render1:opacity"],
+    ["export", "/project1/chop1", "/project1/geo1:ty"]
+  ],
+  "templates": {
+    "t0": {"type": "null", "family": "TOP"},
+    "t1": {"type": "moviefilein", "family": "TOP"}
+  },
+  "operators": {
+    "path": "/",
+    "type": "root",
+    "family": "COMP",
+    "children": [...]
+  }
+}
+```
+
+### Sections
+
+| Section | What it contains |
+|---------|-----------------|
+| `_meta` | Network statistics, subsystem breakdown, cross-subsystem connections |
+| `graph` | All connections as typed edges: `input` (data flow), `bind` (param references), `export` (CHOP/DAT exports) |
+| `templates` | Deduplicated operator configurations -- each unique (type, family, param-set) defined once |
+| `operators` | The operator tree, with templateable operators referencing their template ID |
+
+### Relationship Graph
+
+Connections are extracted into a top-level `graph` array instead of being buried in per-operator fields. This lets an LLM see the full network topology at a glance.
+
+Three edge types:
+- `["input", src_path, dst_path, slot]` -- data flow (operator wiring)
+- `["bind", bind_expr, dst_path:param]` -- parameter binds
+- `["export", src_path, dst_path:param]` -- CHOP/DAT export connections
+
+### Template Deduplication
+
+Operators with identical signatures (same type, family, and set of non-default param names) share a template. The template is defined once; each instance references it with per-instance param values as overrides.
+
+```json
+{
+  "templates": {
+    "t0": {"type": "moviefilein", "family": "TOP"}
+  },
+  "operators": {
+    "path": "/project1",
+    "children": [
+      {"path": "/project1/mov1", "template": "t0", "overrides": {"file": "/video1.mov"}},
+      {"path": "/project1/mov2", "template": "t0", "overrides": {"file": "/video2.mov"}}
+    ]
+  }
+}
+```
 
 ## Output Modes
 
@@ -42,11 +114,9 @@ Control how much detail is exported with `OUTPUT_MODE` at the top of the script:
 ```json
 {
   "path": "/project1/render1",
-  "name": "render1",
   "type": "glslmulti",
   "family": "TOP",
-  "params": {"resolutionw": 1920, "resolutionh": 1080, "outputresolution": 9},
-  "inputs": ["/project1/noise1", "/project1/feedback1"]
+  "params": {"resolutionw": 1920, "resolutionh": 1080, "outputresolution": 9}
 }
 ```
 
@@ -65,7 +135,7 @@ Parameters you never touched are omitted. Expressions, binds, and exports are pr
 ### Summary mode example
 
 ```json
-{"path": "/project1/render1", "type": "glslmulti", "family": "TOP", "inputs": ["/project1/noise1"]}
+{"path": "/project1/render1", "type": "glslmulti", "family": "TOP"}
 ```
 
 No parameters at all -- just the network graph.
@@ -76,16 +146,19 @@ Set `OUTPUT_FORMAT` at the top of the script:
 
 | Format | Description | Output file |
 |--------|------------|-------------|
-| `json` (default) | Nested JSON tree | `network_export.json` |
-| `jsonl` | Flat JSONL, one operator per line | `network_export.jsonl` |
+| `json` (default) | Structured JSON with meta, graph, templates, and operator tree | `network_export.json` |
+| `jsonl` | First line: meta + graph + templates. Remaining lines: one operator each | `network_export.jsonl` |
 
-**JSONL** is useful for very large networks -- you can grep it, load specific operators, or stream it line by line. Each line is a self-contained JSON object with the operator's `path` encoding its position in the hierarchy.
+**JSONL** is useful for very large networks -- you can grep it, load specific operators, or stream it line by line.
 
 ## Filtering
 
 Use filters to export only what you need. Set them at the top of `export_network.py`:
 
 ```python
+# Skip TD system/UI internals (default: True)
+EXCLUDE_SYSTEM = True
+
 # Only export TOP and CHOP operators
 FILTER_FAMILIES = ['TOP', 'CHOP']
 
@@ -124,19 +197,23 @@ export_network(
     output_format='jsonl',
     output_filename='tops_summary.jsonl'
 )
+
+# Include system operators for debugging TD internals
+export_network(exclude_system=False)
 ```
 
 ## Size Comparison
 
-On a real-world Gaussian splatting project (19,377 operators):
+On a real-world Gaussian splatting project (19,377 total operators):
 
-| Configuration | Size | Reduction |
-|--------------|------|-----------|
-| Original (pretty JSON, all pages) | 23.5 MB | -- |
-| Compact JSON (non-default params, minified) | ~2.9 MB | 88% |
-| Summary JSONL (tree + connections only) | ~2.4 MB | 90% |
+| Configuration | Size | Tokens (est) |
+|--------------|------|-------------|
+| Original (pretty JSON, all pages) | 23.5 MB | ~6M |
+| v1 compact (all operators) | ~2.9 MB | ~760K |
+| v2 compact (system excluded, templates) | ~57 KB | ~15K |
+| v2 summary (tree + connections only) | ~40 KB | ~10K |
 
-With filtering applied (e.g., only TOPs in one subtree), output typically drops to KB range.
+98% of operators in the example project are TD system/UI boilerplate. Excluding them is the single biggest optimization.
 
 ## Configuration
 
@@ -144,8 +221,9 @@ Settings at the top of `export_network.py`:
 
 - **`OUTPUT_MODE`** -- `'compact'`, `'summary'`, or `'full'` (default: `'compact'`)
 - **`OUTPUT_FORMAT`** -- `'json'` or `'jsonl'` (default: `'json'`)
+- **`EXCLUDE_SYSTEM`** -- skip `/sys` and `/ui` subtrees (default: `True`)
 - **`FILTER_MAX_DEPTH`** -- how deep to recurse into nested COMPs (default: 6)
-- **Root operator** -- change `op('/')` to export a subtree instead of the whole project
+- **Root operator** -- change `root_path` in `export_network()` to export a subtree
 
 ## Requirements
 

--- a/export_network.py
+++ b/export_network.py
@@ -17,6 +17,14 @@ Outputs to: [project folder]/network_export.json
     OUTPUT_FORMAT = 'json'    Nested JSON (default)
     OUTPUT_FORMAT = 'jsonl'   Flat JSONL, one operator per line (grep-friendly)
 
+## System Filtering
+
+    EXCLUDE_SYSTEM = True     Skip /sys and /ui subtrees (default: True)
+
+TD projects contain thousands of system and UI operators that are identical
+across all projects. These are noise for LLM context. Set to False only if
+you specifically need to inspect TD internals.
+
 ## Filtering
 
 Set any combination of filters below to reduce the export size.
@@ -42,6 +50,16 @@ from fnmatch import fnmatch
 OUTPUT_MODE = 'compact'        # 'compact', 'summary', or 'full'
 OUTPUT_FORMAT = 'json'         # 'json' or 'jsonl'
 
+# ─── System Filtering ─────────────────────────────────────────────────
+# TD projects contain thousands of system/UI operators identical across
+# all projects. Exclude them by default to focus on user content.
+
+EXCLUDE_SYSTEM = True           # Skip /sys, /ui subtrees
+
+# Paths excluded when EXCLUDE_SYSTEM is True. These are TD internal
+# subsystems that are the same in every project.
+_SYSTEM_PATHS = ('/sys', '/ui')
+
 # ─── Filter Configuration ─────────────────────────────────────────────
 # Set these to control what gets exported. None or [] means "no filter".
 
@@ -53,6 +71,31 @@ INCLUDE_PATTERNS = None         # e.g. ['render*', '*_out'] (fnmatch on op name)
 EXCLUDE_PATTERNS = None         # e.g. ['__*', 'local*'] (fnmatch on op name)
 
 # ─── End Configuration ─────────────────────────────────────────────────
+
+
+# ─── Graph Collector ──────────────────────────────────────────────────
+# Accumulates connection edges during serialization for the top-level
+# relationship graph. Three edge types:
+#   ["input",  src_path, dst_path, slot]  -- data flow
+#   ["bind",   src_expr, dst_path:par]    -- parameter bind
+#   ["export", src_path, dst_path:par]    -- CHOP/DAT export
+
+_graph_edges = []
+
+
+def _reset_graph():
+    global _graph_edges
+    _graph_edges = []
+
+
+# ─── Filter Functions ─────────────────────────────────────────────────
+
+def _is_system_path(path):
+    """Check if a path is under a TD system subtree."""
+    for sp in _SYSTEM_PATHS:
+        if path == sp or path.startswith(sp + '/'):
+            return True
+    return False
 
 
 def matches_filters(operator):
@@ -94,17 +137,15 @@ def path_could_contain_prefix(op_path):
     if not FILTER_PATH_PREFIX:
         return True
     prefix = FILTER_PATH_PREFIX.rstrip('/')
-    # Operator is at or under the prefix
     if op_path.startswith(prefix + '/') or op_path == prefix:
         return True
-    # Prefix is deeper than this operator (children might match)
     if prefix.startswith(op_path + '/') or prefix == op_path:
         return True
     return False
 
 
 def has_active_filters():
-    """Return True if any filter other than max_depth is set."""
+    """Return True if any filter other than max_depth and EXCLUDE_SYSTEM is set."""
     return any([FILTER_FAMILIES, FILTER_TYPES, FILTER_PATH_PREFIX,
                 INCLUDE_PATTERNS, EXCLUDE_PATTERNS])
 
@@ -115,12 +156,15 @@ def has_active_filters():
 _SKIP_STYLES = {'Pulse', 'Header'}
 
 
-def serialize_par(par):
+def serialize_par(par, owner_path=None):
     """Serialize a single non-default parameter.
 
     Returns a dict with the parameter value (and expression/mode if
     not in constant mode). Returns None for parameters that should
     be skipped (pulses, headers, read-only with no expression).
+
+    When owner_path is provided, bind/export edges are added to the
+    global graph collector.
     """
     try:
         if par.isDefault:
@@ -144,22 +188,24 @@ def serialize_par(par):
         if mode == ParMode.EXPRESSION:
             result['expr'] = par.expr
         elif mode == ParMode.EXPORT:
-            # Export mode: parameter is driven by an export CHOP/DAT
             try:
-                result['export'] = par.exportSource.path if par.exportSource else True
+                source = par.exportSource.path if par.exportSource else None
+                result['export'] = source if source else True
+                if source and owner_path:
+                    _graph_edges.append(['export', source, owner_path + ':' + par.name])
             except (AttributeError, TypeError):
                 result['export'] = True
         elif mode == ParMode.BIND:
-            # Bind mode: parameter references another parameter
             try:
-                result['bind'] = par.bindExpr
+                bind_expr = par.bindExpr
+                result['bind'] = bind_expr
+                if bind_expr and owner_path:
+                    _graph_edges.append(['bind', bind_expr, owner_path + ':' + par.name])
             except (AttributeError, TypeError):
                 result['bind'] = True
         else:
-            # Constant mode -- just store the value
             result['val'] = par.val
     except (AttributeError, TypeError):
-        # Fallback: try to get any value
         try:
             result['val'] = par.val
         except (AttributeError, TypeError):
@@ -171,13 +217,13 @@ def serialize_par(par):
     return result
 
 
-def serialize_par_full(par):
+def serialize_par_full(par, owner_path=None):
     """Serialize a non-default parameter with full metadata.
 
     Includes style (type), label, and range info in addition to value.
     Used by OUTPUT_MODE = 'full'.
     """
-    base = serialize_par(par)
+    base = serialize_par(par, owner_path)
     if base is None:
         return None
 
@@ -214,9 +260,8 @@ def serialize_params(operator):
 
     try:
         for par in operator.pars():
-            data = serialize_fn(par)
+            data = serialize_fn(par, owner_path=operator.path)
             if data is not None:
-                # In compact mode, flatten constant-mode params to bare values
                 if OUTPUT_MODE == 'compact' and list(data.keys()) == ['val']:
                     params[par.name] = data['val']
                 else:
@@ -232,11 +277,15 @@ def serialize_params(operator):
 def serialize_op(operator, depth=0):
     """Serialize an operator and its children recursively.
 
-    When filters are active, containers are only included if they have
-    matching descendants. This keeps the hierarchy readable while still
-    trimming the output aggressively.
+    Connections are collected into the global graph rather than stored
+    per-operator. When filters are active, containers are only included
+    if they have matching descendants.
     """
     if depth > FILTER_MAX_DEPTH:
+        return None
+
+    # System path exclusion (before other filters)
+    if EXCLUDE_SYSTEM and depth == 1 and _is_system_path(operator.path):
         return None
 
     if not path_could_contain_prefix(operator.path):
@@ -244,7 +293,6 @@ def serialize_op(operator, depth=0):
 
     node = {
         'path': operator.path,
-        'name': operator.name,
         'type': operator.type,
         'family': operator.family,
     }
@@ -254,24 +302,14 @@ def serialize_op(operator, depth=0):
     if params:
         node['params'] = params
 
-    # Connections: inputs (compact format -- path array with None for empty slots)
+    # Collect connections into the top-level graph
     try:
-        inputs = [inp.path if inp is not None else None for inp in operator.inputs]
-        # Strip trailing Nones but preserve internal gaps for slot accuracy
-        while inputs and inputs[-1] is None:
-            inputs.pop()
-        if inputs:
-            node['inputs'] = inputs
-    except Exception:
-        pass
-
-    # Connections: outputs (compact format -- path array with None for empty slots)
-    try:
-        outputs = [out.path if out is not None else None for out in operator.outputs]
-        while outputs and outputs[-1] is None:
-            outputs.pop()
-        if outputs:
-            node['outputs'] = outputs
+        inputs = operator.inputs
+        for slot, inp in enumerate(inputs):
+            if inp is not None:
+                # Only add edge if source isn't in an excluded system path
+                if not (EXCLUDE_SYSTEM and _is_system_path(inp.path)):
+                    _graph_edges.append(['input', inp.path, operator.path, slot])
     except Exception:
         pass
 
@@ -291,14 +329,10 @@ def serialize_op(operator, depth=0):
     except Exception:
         pass
 
-    # Filtering logic:
-    # - If no filters are active, include everything (original behavior)
-    # - Containers are included only if they have matching children
-    # - Leaf ops are included only if they pass all filters
+    # Filtering logic
     if has_active_filters():
         if is_container:
             if 'children' not in node or not node['children']:
-                # Container with no matching descendants -- check if it matches on its own
                 if not matches_filters(operator):
                     return None
         else:
@@ -324,13 +358,136 @@ def flatten_ops(node):
     return ops
 
 
+# ─── Template Detection ──────────────────────────────────────────────
+
+def _detect_templates(root_node):
+    """Detect repeated operator signatures and extract templates.
+
+    A signature is (type, family, frozenset of non-default param names).
+    Operators sharing a signature get a template; per-instance param
+    values become overrides.
+
+    Returns:
+        templates: dict of {template_id: {type, family}}
+        The root_node is modified in-place -- templateable operators get
+        'template' and optional 'overrides' keys, with type/family/params removed.
+    """
+    # First pass: collect all leaf operators by signature
+    sig_groups = {}  # signature -> list of node references
+
+    def collect_leaves(node):
+        if 'children' in node:
+            for child in node['children']:
+                collect_leaves(child)
+        else:
+            param_keys = frozenset(node.get('params', {}).keys()) if 'params' in node else frozenset()
+            sig = (node['type'], node['family'], param_keys)
+            sig_groups.setdefault(sig, []).append(node)
+
+    collect_leaves(root_node)
+
+    # Only create templates for signatures with 2+ instances
+    templates = {}
+    template_counter = 0
+
+    for sig, nodes in sig_groups.items():
+        if len(nodes) < 2:
+            continue
+
+        op_type, op_family, param_keys = sig
+        template_id = 't' + str(template_counter)
+        template_counter += 1
+
+        templates[template_id] = {
+            'type': op_type,
+            'family': op_family,
+        }
+
+        # Rewrite each node to reference the template
+        for node in nodes:
+            overrides = node.pop('params', None)
+            node.pop('type', None)
+            node.pop('family', None)
+            node['template'] = template_id
+            if overrides:
+                node['overrides'] = overrides
+
+    return templates
+
+
+# ─── Metadata Generation ─────────────────────────────────────────────
+
+def _generate_meta(root_node, graph_edges):
+    """Generate the _meta section with network statistics.
+
+    Must be called BEFORE _detect_templates, which pops type/family
+    from templated nodes.
+    """
+    total_ops = _count_subtree(root_node)
+    subsystems = {}
+
+    for child in root_node.get('children', []):
+        sub_count = _count_subtree(child)
+        sub_types = {}
+        _count_types(child, sub_types)
+        subsystems[child['path']] = {
+            'ops': sub_count,
+            'types': sub_types,
+        }
+
+    # Cross-subsystem connections
+    cross_edges = []
+    for edge in graph_edges:
+        if edge[0] == 'input':
+            src_sub = _get_subsystem(edge[1])
+            dst_sub = _get_subsystem(edge[2])
+            if src_sub and dst_sub and src_sub != dst_sub:
+                cross_edges.append(edge)
+
+    meta = {
+        'total_ops': total_ops,
+        'connections': len(graph_edges),
+        'subsystems': subsystems,
+    }
+
+    if cross_edges:
+        meta['cross_subsystem_connections'] = cross_edges
+
+    if EXCLUDE_SYSTEM:
+        meta['system_excluded'] = list(_SYSTEM_PATHS)
+
+    return meta
+
+
+def _count_subtree(node):
+    count = 1
+    for child in node.get('children', []):
+        count += _count_subtree(child)
+    return count
+
+
+def _count_types(node, types_dict):
+    family = node.get('family', '?')
+    types_dict[family] = types_dict.get(family, 0) + 1
+    for child in node.get('children', []):
+        _count_types(child, types_dict)
+
+
+def _get_subsystem(path):
+    """Extract the top-level subsystem from a path (e.g., '/project1' from '/project1/op1')."""
+    parts = path.strip('/').split('/')
+    if parts:
+        return '/' + parts[0]
+    return None
+
+
 # ─── Main ──────────────────────────────────────────────────────────────
 
 def export_network(root_path='/', output_filename=None,
                    families=None, types=None, path_prefix=None,
                    max_depth=None, include_patterns=None,
                    exclude_patterns=None, output_mode=None,
-                   output_format=None):
+                   output_format=None, exclude_system=None):
     """Export the operator network with optional filtering and format control.
 
     Can be called as a function for programmatic use, or the script
@@ -347,13 +504,14 @@ def export_network(root_path='/', output_filename=None,
         exclude_patterns: fnmatch patterns for operator names to exclude
         output_mode: 'compact', 'summary', or 'full'
         output_format: 'json' or 'jsonl'
+        exclude_system: Skip /sys and /ui subtrees (default: True)
 
     Returns:
-        The serialized data (dict for json, list for jsonl).
+        The structured export data.
     """
     global FILTER_FAMILIES, FILTER_TYPES, FILTER_PATH_PREFIX
     global FILTER_MAX_DEPTH, INCLUDE_PATTERNS, EXCLUDE_PATTERNS
-    global OUTPUT_MODE, OUTPUT_FORMAT
+    global OUTPUT_MODE, OUTPUT_FORMAT, EXCLUDE_SYSTEM
 
     if families is not None:
         FILTER_FAMILIES = families
@@ -371,27 +529,52 @@ def export_network(root_path='/', output_filename=None,
         OUTPUT_MODE = output_mode
     if output_format is not None:
         OUTPUT_FORMAT = output_format
+    if exclude_system is not None:
+        EXCLUDE_SYSTEM = exclude_system
 
     # Default filename based on format
     if output_filename is None:
         ext = 'jsonl' if OUTPUT_FORMAT == 'jsonl' else 'json'
         output_filename = f'network_export.{ext}'
 
+    # Reset and serialize
+    _reset_graph()
     root = op(root_path)
-    data = serialize_op(root)
+    operator_tree = serialize_op(root)
+
+    # Generate metadata (must run before template detection, which pops type/family)
+    meta = _generate_meta(operator_tree, _graph_edges) if operator_tree else {}
+
+    # Detect templates (modifies tree in-place)
+    templates = _detect_templates(operator_tree) if operator_tree else {}
+
+    # Build structured output
+    export_data = {
+        '_meta': meta,
+        'graph': _graph_edges,
+    }
+    if templates:
+        export_data['templates'] = templates
+    export_data['operators'] = operator_tree
 
     output_path = project.folder + '/' + output_filename
 
     if OUTPUT_FORMAT == 'jsonl':
-        ops = flatten_ops(data) if data else []
+        # JSONL: first line is meta+graph+templates, then one line per operator
+        ops = flatten_ops(operator_tree) if operator_tree else []
         with open(output_path, 'w') as f:
+            header = {'_meta': meta, 'graph': _graph_edges}
+            if templates:
+                header['templates'] = templates
+            header_str = json.dumps(header, default=str)
+            f.write(header_str + '\n')
             for entry in ops:
                 f.write(json.dumps(entry, default=str) + '\n')
-        size_kb = sum(len(json.dumps(e, default=str)) for e in ops) / 1024
+        size_kb = (len(header_str) + sum(len(json.dumps(e, default=str)) for e in ops)) / 1024
         print(f"Exported {len(ops)} operators to: {output_path}")
     else:
         indent = None if OUTPUT_MODE == 'compact' else 2
-        json_str = json.dumps(data, indent=indent, default=str)
+        json_str = json.dumps(export_data, indent=indent, default=str)
         with open(output_path, 'w') as f:
             f.write(json_str)
         size_kb = len(json_str) / 1024
@@ -399,6 +582,15 @@ def export_network(root_path='/', output_filename=None,
 
     print(f"Output size: {size_kb:.0f} KB")
     print(f"Mode: {OUTPUT_MODE}, Format: {OUTPUT_FORMAT}")
+
+    if templates:
+        template_ops = sum(1 for _ in _iter_ops(operator_tree) if 'template' in _)
+        print(f"Templates: {len(templates)} (covering {template_ops} operators)")
+
+    print(f"Graph edges: {len(_graph_edges)}")
+
+    if EXCLUDE_SYSTEM:
+        print(f"System paths excluded: {', '.join(_SYSTEM_PATHS)}")
 
     active = []
     if FILTER_FAMILIES:
@@ -415,7 +607,14 @@ def export_network(root_path='/', output_filename=None,
     if active:
         print(f"Active filters: {', '.join(active)}")
 
-    return ops if OUTPUT_FORMAT == 'jsonl' else data
+    return export_data
+
+
+def _iter_ops(node):
+    """Iterate all operators in a tree (depth-first)."""
+    yield node
+    for child in node.get('children', []):
+        yield from _iter_ops(child)
 
 
 # When run directly (exec from Text DAT), use module-level config

--- a/export_network.py
+++ b/export_network.py
@@ -1,10 +1,21 @@
 """
-Export TouchDesigner network to JSON using TDJSON for parameter serialization.
+Export TouchDesigner network to JSON for LLM context.
 
 Run from a Text DAT or paste into the textport:
     exec(op('export_network').text)
 
 Outputs to: [project folder]/network_export.json
+
+## Output Modes
+
+    OUTPUT_MODE = 'compact'   Only non-default parameters (recommended, smallest)
+    OUTPUT_MODE = 'summary'   Operator tree + connections only, no parameters
+    OUTPUT_MODE = 'full'      All non-default parameters with metadata (style, mode)
+
+## Output Formats
+
+    OUTPUT_FORMAT = 'json'    Nested JSON (default)
+    OUTPUT_FORMAT = 'jsonl'   Flat JSONL, one operator per line (grep-friendly)
 
 ## Filtering
 
@@ -25,6 +36,12 @@ so the hierarchy stays intact even when filtering by type or family.
 import json
 from fnmatch import fnmatch
 
+# ─── Output Configuration ────────────────────────────────────────────
+# Controls how much detail is exported and in what format.
+
+OUTPUT_MODE = 'compact'        # 'compact', 'summary', or 'full'
+OUTPUT_FORMAT = 'json'         # 'json' or 'jsonl'
+
 # ─── Filter Configuration ─────────────────────────────────────────────
 # Set these to control what gets exported. None or [] means "no filter".
 
@@ -36,12 +53,6 @@ INCLUDE_PATTERNS = None         # e.g. ['render*', '*_out'] (fnmatch on op name)
 EXCLUDE_PATTERNS = None         # e.g. ['__*', 'local*'] (fnmatch on op name)
 
 # ─── End Configuration ─────────────────────────────────────────────────
-
-try:
-    import TDJSON
-    HAS_TDJSON = True
-except ImportError:
-    HAS_TDJSON = False
 
 
 def matches_filters(operator):
@@ -98,6 +109,126 @@ def has_active_filters():
                 INCLUDE_PATTERNS, EXCLUDE_PATTERNS])
 
 
+# ─── Parameter Serialization ─────────────────────────────────────────
+
+# Parameter styles that are never useful to export
+_SKIP_STYLES = {'Pulse', 'Header'}
+
+
+def serialize_par(par):
+    """Serialize a single non-default parameter.
+
+    Returns a dict with the parameter value (and expression/mode if
+    not in constant mode). Returns None for parameters that should
+    be skipped (pulses, headers, read-only with no expression).
+    """
+    try:
+        if par.isDefault:
+            return None
+    except (AttributeError, TypeError):
+        return None
+
+    # Skip pulse buttons, headers, and read-only params with no expression
+    try:
+        if par.style in _SKIP_STYLES:
+            return None
+        if par.readOnly and par.mode == ParMode.CONSTANT:
+            return None
+    except (AttributeError, TypeError):
+        pass
+
+    result = {}
+
+    try:
+        mode = par.mode
+        if mode == ParMode.EXPRESSION:
+            result['expr'] = par.expr
+        elif mode == ParMode.EXPORT:
+            # Export mode: parameter is driven by an export CHOP/DAT
+            try:
+                result['export'] = par.exportSource.path if par.exportSource else True
+            except (AttributeError, TypeError):
+                result['export'] = True
+        elif mode == ParMode.BIND:
+            # Bind mode: parameter references another parameter
+            try:
+                result['bind'] = par.bindExpr
+            except (AttributeError, TypeError):
+                result['bind'] = True
+        else:
+            # Constant mode -- just store the value
+            result['val'] = par.val
+    except (AttributeError, TypeError):
+        # Fallback: try to get any value
+        try:
+            result['val'] = par.val
+        except (AttributeError, TypeError):
+            return None
+
+    if not result:
+        return None
+
+    return result
+
+
+def serialize_par_full(par):
+    """Serialize a non-default parameter with full metadata.
+
+    Includes style (type), label, and range info in addition to value.
+    Used by OUTPUT_MODE = 'full'.
+    """
+    base = serialize_par(par)
+    if base is None:
+        return None
+
+    try:
+        base['style'] = par.style
+    except (AttributeError, TypeError):
+        pass
+    try:
+        if par.label and par.label != par.name:
+            base['label'] = par.label
+    except (AttributeError, TypeError):
+        pass
+
+    return base
+
+
+def serialize_params(operator):
+    """Serialize all non-default parameters for an operator.
+
+    Returns a dict of {par_name: value_or_info} for parameters that
+    differ from their defaults. Returns None if no non-default params.
+
+    In compact mode, constant-mode parameters are stored as bare values:
+        {"file": "/path/to/file.mov", "resolutionw": 1920}
+
+    Parameters with expressions/binds/exports use nested dicts:
+        {"tx": {"expr": "absTime.seconds"}}
+    """
+    if OUTPUT_MODE == 'summary':
+        return None
+
+    serialize_fn = serialize_par_full if OUTPUT_MODE == 'full' else serialize_par
+    params = {}
+
+    try:
+        for par in operator.pars():
+            data = serialize_fn(par)
+            if data is not None:
+                # In compact mode, flatten constant-mode params to bare values
+                if OUTPUT_MODE == 'compact' and list(data.keys()) == ['val']:
+                    params[par.name] = data['val']
+                else:
+                    params[par.name] = data
+    except Exception:
+        pass
+
+    return params if params else None
+
+
+# ─── Operator Serialization ──────────────────────────────────────────
+
 def serialize_op(operator, depth=0):
     """Serialize an operator and its children recursively.
 
@@ -118,47 +249,30 @@ def serialize_op(operator, depth=0):
         'family': operator.family,
     }
 
-    # Use TDJSON to serialize each parameter page
-    if HAS_TDJSON:
-        try:
-            pages = {}
-            for page in operator.pages:
-                page_data = TDJSON.serializeTDData(page, verbose=True)
-                if page_data:
-                    pages[page.name] = page_data
-            if pages:
-                node['pages'] = pages
-        except:
-            pass
+    # Parameters (non-default only)
+    params = serialize_params(operator)
+    if params:
+        node['params'] = params
 
-    # Connections: inputs
+    # Connections: inputs (compact format -- path array with None for empty slots)
     try:
-        inputs = []
-        for i, inp in enumerate(operator.inputs):
-            if inp is not None:
-                inputs.append({
-                    'index': i,
-                    'path': inp.path,
-                    'name': inp.name,
-                })
+        inputs = [inp.path if inp is not None else None for inp in operator.inputs]
+        # Strip trailing Nones but preserve internal gaps for slot accuracy
+        while inputs and inputs[-1] is None:
+            inputs.pop()
         if inputs:
             node['inputs'] = inputs
-    except:
+    except Exception:
         pass
 
-    # Connections: outputs
+    # Connections: outputs (compact format -- path array with None for empty slots)
     try:
-        outputs = []
-        for i, out in enumerate(operator.outputs):
-            if out is not None:
-                outputs.append({
-                    'index': i,
-                    'path': out.path,
-                    'name': out.name,
-                })
+        outputs = [out.path if out is not None else None for out in operator.outputs]
+        while outputs and outputs[-1] is None:
+            outputs.pop()
         if outputs:
             node['outputs'] = outputs
-    except:
+    except Exception:
         pass
 
     # Recurse into children (COMPs only)
@@ -174,7 +288,7 @@ def serialize_op(operator, depth=0):
                     children.append(child_data)
             if children:
                 node['children'] = children
-    except:
+    except Exception:
         pass
 
     # Filtering logic:
@@ -194,32 +308,52 @@ def serialize_op(operator, depth=0):
     return node
 
 
+# ─── JSONL Flattening ─────────────────────────────────────────────────
+
+def flatten_ops(node):
+    """Flatten a nested operator tree into a list of operators.
+
+    Each operator keeps its path (encodes hierarchy) but children
+    are extracted into separate entries. Used for JSONL output.
+    """
+    ops = []
+    flat_node = {k: v for k, v in node.items() if k != 'children'}
+    ops.append(flat_node)
+    for child in node.get('children', []):
+        ops.extend(flatten_ops(child))
+    return ops
+
+
 # ─── Main ──────────────────────────────────────────────────────────────
 
-def export_network(root_path='/', output_filename='network_export.json',
+def export_network(root_path='/', output_filename=None,
                    families=None, types=None, path_prefix=None,
                    max_depth=None, include_patterns=None,
-                   exclude_patterns=None):
-    """Export the operator network to JSON with optional filtering.
+                   exclude_patterns=None, output_mode=None,
+                   output_format=None):
+    """Export the operator network with optional filtering and format control.
 
     Can be called as a function for programmatic use, or the script
     can be run directly with the module-level configuration variables.
 
     Args:
         root_path: Starting operator path (default: '/')
-        output_filename: Output filename in project folder
+        output_filename: Output filename in project folder (auto-set if None)
         families: List of operator families, e.g. ['TOP', 'CHOP']
         types: List of operator types, e.g. ['moviefilein', 'null']
         path_prefix: Only export ops under this path
         max_depth: Max recursion depth (default: 6)
         include_patterns: fnmatch patterns for operator names to include
         exclude_patterns: fnmatch patterns for operator names to exclude
+        output_mode: 'compact', 'summary', or 'full'
+        output_format: 'json' or 'jsonl'
 
     Returns:
-        The serialized data dict.
+        The serialized data (dict for json, list for jsonl).
     """
     global FILTER_FAMILIES, FILTER_TYPES, FILTER_PATH_PREFIX
     global FILTER_MAX_DEPTH, INCLUDE_PATTERNS, EXCLUDE_PATTERNS
+    global OUTPUT_MODE, OUTPUT_FORMAT
 
     if families is not None:
         FILTER_FAMILIES = families
@@ -233,13 +367,38 @@ def export_network(root_path='/', output_filename='network_export.json',
         INCLUDE_PATTERNS = include_patterns
     if exclude_patterns is not None:
         EXCLUDE_PATTERNS = exclude_patterns
+    if output_mode is not None:
+        OUTPUT_MODE = output_mode
+    if output_format is not None:
+        OUTPUT_FORMAT = output_format
+
+    # Default filename based on format
+    if output_filename is None:
+        ext = 'jsonl' if OUTPUT_FORMAT == 'jsonl' else 'json'
+        output_filename = f'network_export.{ext}'
 
     root = op(root_path)
     data = serialize_op(root)
 
     output_path = project.folder + '/' + output_filename
-    with open(output_path, 'w') as f:
-        json.dump(data, f, indent=2, default=str)
+
+    if OUTPUT_FORMAT == 'jsonl':
+        ops = flatten_ops(data) if data else []
+        with open(output_path, 'w') as f:
+            for entry in ops:
+                f.write(json.dumps(entry, default=str) + '\n')
+        size_kb = sum(len(json.dumps(e, default=str)) for e in ops) / 1024
+        print(f"Exported {len(ops)} operators to: {output_path}")
+    else:
+        indent = None if OUTPUT_MODE == 'compact' else 2
+        json_str = json.dumps(data, indent=indent, default=str)
+        with open(output_path, 'w') as f:
+            f.write(json_str)
+        size_kb = len(json_str) / 1024
+        print(f"Exported network to: {output_path}")
+
+    print(f"Output size: {size_kb:.0f} KB")
+    print(f"Mode: {OUTPUT_MODE}, Format: {OUTPUT_FORMAT}")
 
     active = []
     if FILTER_FAMILIES:
@@ -253,36 +412,11 @@ def export_network(root_path='/', output_filename='network_export.json',
     if EXCLUDE_PATTERNS:
         active.append('exclude=' + str(EXCLUDE_PATTERNS))
     active.append('max_depth=' + str(FILTER_MAX_DEPTH))
-
-    size_kb = len(json.dumps(data, default=str)) / 1024
-    print(f"Exported network to: {output_path}")
-    print(f"Total JSON size: {size_kb:.0f} KB")
     if active:
         print(f"Active filters: {', '.join(active)}")
 
-    return data
+    return ops if OUTPUT_FORMAT == 'jsonl' else data
 
 
 # When run directly (exec from Text DAT), use module-level config
-root = op('/')
-data = serialize_op(root)
-
-output_path = project.folder + '/network_export.json'
-with open(output_path, 'w') as f:
-    json.dump(data, f, indent=2, default=str)
-
-print(f"Exported network to: {output_path}")
-print(f"Total JSON size: {len(json.dumps(data, default=str)) / 1024:.0f} KB")
-if has_active_filters():
-    filters = []
-    if FILTER_FAMILIES:
-        filters.append(f"families={FILTER_FAMILIES}")
-    if FILTER_TYPES:
-        filters.append(f"types={FILTER_TYPES}")
-    if FILTER_PATH_PREFIX:
-        filters.append(f"path_prefix={FILTER_PATH_PREFIX}")
-    if INCLUDE_PATTERNS:
-        filters.append(f"include={INCLUDE_PATTERNS}")
-    if EXCLUDE_PATTERNS:
-        filters.append(f"exclude={EXCLUDE_PATTERNS}")
-    print(f"Active filters: {', '.join(filters)}")
+export_network()

--- a/export_network.py
+++ b/export_network.py
@@ -5,87 +5,284 @@ Run from a Text DAT or paste into the textport:
     exec(op('export_network').text)
 
 Outputs to: [project folder]/network_export.json
+
+## Filtering
+
+Set any combination of filters below to reduce the export size.
+All filters are optional -- leave as None or empty to disable.
+
+    FILTER_FAMILIES     Only include these operator families (e.g. ['TOP', 'CHOP'])
+    FILTER_TYPES        Only include these operator types (e.g. ['moviefilein', 'null'])
+    FILTER_PATH_PREFIX  Only include operators under this path (e.g. '/project1/fx')
+    FILTER_MAX_DEPTH    Max recursion depth from root (default: 6)
+    INCLUDE_PATTERNS    Include operators whose names match these patterns (fnmatch)
+    EXCLUDE_PATTERNS    Exclude operators whose names match these patterns (fnmatch)
+
+Containers (COMPs) are kept in the output when they have matching descendants,
+so the hierarchy stays intact even when filtering by type or family.
 """
 
 import json
-import TDJSON
+from fnmatch import fnmatch
 
-def serialize_op(operator, depth=0, max_depth=5):
-	"""Serialize an operator and its children recursively."""
-	if depth > max_depth:
-		return None
+# ─── Filter Configuration ─────────────────────────────────────────────
+# Set these to control what gets exported. None or [] means "no filter".
 
-	node = {
-		'path': operator.path,
-		'name': operator.name,
-		'type': operator.type,
-		'family': operator.family,
-	}
+FILTER_FAMILIES = None          # e.g. ['TOP', 'CHOP', 'SOP']
+FILTER_TYPES = None             # e.g. ['moviefilein', 'null', 'geo']
+FILTER_PATH_PREFIX = None       # e.g. '/project1/fx'
+FILTER_MAX_DEPTH = 6            # max recursion depth from root
+INCLUDE_PATTERNS = None         # e.g. ['render*', '*_out'] (fnmatch on op name)
+EXCLUDE_PATTERNS = None         # e.g. ['__*', 'local*'] (fnmatch on op name)
 
-	# Use TDJSON to serialize each parameter page
-	try:
-		pages = {}
-		for page in operator.pages:
-			page_data = TDJSON.serializeTDData(page, verbose=True)
-			if page_data:
-				pages[page.name] = page_data
-		if pages:
-			node['pages'] = pages
-	except:
-		pass
+# ─── End Configuration ─────────────────────────────────────────────────
 
-	# Connections: inputs
-	try:
-		inputs = []
-		for i, inp in enumerate(operator.inputs):
-			if inp is not None:
-				inputs.append({
-					'index': i,
-					'path': inp.path,
-					'name': inp.name,
-				})
-		if inputs:
-			node['inputs'] = inputs
-	except:
-		pass
+try:
+    import TDJSON
+    HAS_TDJSON = True
+except ImportError:
+    HAS_TDJSON = False
 
-	# Connections: outputs
-	try:
-		outputs = []
-		for i, out in enumerate(operator.outputs):
-			if out is not None:
-				outputs.append({
-					'index': i,
-					'path': out.path,
-					'name': out.name,
-				})
-		if outputs:
-			node['outputs'] = outputs
-	except:
-		pass
 
-	# Recurse into children (COMPs only)
-	try:
-		kids = operator.children
-		if kids:
-			node['children'] = []
-			for child in sorted(kids, key=lambda c: c.name):
-				child_data = serialize_op(child, depth + 1, max_depth)
-				if child_data:
-					node['children'].append(child_data)
-	except:
-		pass
+def matches_filters(operator):
+    """Check if a leaf operator passes all active filters.
 
-	return node
+    Containers (COMPs) are handled separately during recursion -- they're
+    included when they have any matching descendants. This function is for
+    deciding whether a non-container op should appear in the output.
+    """
+    if FILTER_FAMILIES and operator.family not in FILTER_FAMILIES:
+        return False
 
-# Serialize from project root
+    if FILTER_TYPES and operator.type not in FILTER_TYPES:
+        return False
+
+    if FILTER_PATH_PREFIX:
+        prefix = FILTER_PATH_PREFIX.rstrip('/')
+        if not operator.path.startswith(prefix + '/') and operator.path != prefix:
+            return False
+
+    if INCLUDE_PATTERNS:
+        if not any(fnmatch(operator.name, pat) for pat in INCLUDE_PATTERNS):
+            return False
+
+    if EXCLUDE_PATTERNS:
+        if any(fnmatch(operator.name, pat) for pat in EXCLUDE_PATTERNS):
+            return False
+
+    return True
+
+
+def path_could_contain_prefix(op_path):
+    """Check if an operator's subtree could contain the target path prefix.
+
+    Returns True if:
+    - The operator IS at or under the prefix, or
+    - The prefix is deeper than this operator (so children might match)
+    """
+    if not FILTER_PATH_PREFIX:
+        return True
+    prefix = FILTER_PATH_PREFIX.rstrip('/')
+    # Operator is at or under the prefix
+    if op_path.startswith(prefix + '/') or op_path == prefix:
+        return True
+    # Prefix is deeper than this operator (children might match)
+    if prefix.startswith(op_path + '/') or prefix == op_path:
+        return True
+    return False
+
+
+def has_active_filters():
+    """Return True if any filter other than max_depth is set."""
+    return any([FILTER_FAMILIES, FILTER_TYPES, FILTER_PATH_PREFIX,
+                INCLUDE_PATTERNS, EXCLUDE_PATTERNS])
+
+
+def serialize_op(operator, depth=0):
+    """Serialize an operator and its children recursively.
+
+    When filters are active, containers are only included if they have
+    matching descendants. This keeps the hierarchy readable while still
+    trimming the output aggressively.
+    """
+    if depth > FILTER_MAX_DEPTH:
+        return None
+
+    if not path_could_contain_prefix(operator.path):
+        return None
+
+    node = {
+        'path': operator.path,
+        'name': operator.name,
+        'type': operator.type,
+        'family': operator.family,
+    }
+
+    # Use TDJSON to serialize each parameter page
+    if HAS_TDJSON:
+        try:
+            pages = {}
+            for page in operator.pages:
+                page_data = TDJSON.serializeTDData(page, verbose=True)
+                if page_data:
+                    pages[page.name] = page_data
+            if pages:
+                node['pages'] = pages
+        except:
+            pass
+
+    # Connections: inputs
+    try:
+        inputs = []
+        for i, inp in enumerate(operator.inputs):
+            if inp is not None:
+                inputs.append({
+                    'index': i,
+                    'path': inp.path,
+                    'name': inp.name,
+                })
+        if inputs:
+            node['inputs'] = inputs
+    except:
+        pass
+
+    # Connections: outputs
+    try:
+        outputs = []
+        for i, out in enumerate(operator.outputs):
+            if out is not None:
+                outputs.append({
+                    'index': i,
+                    'path': out.path,
+                    'name': out.name,
+                })
+        if outputs:
+            node['outputs'] = outputs
+    except:
+        pass
+
+    # Recurse into children (COMPs only)
+    is_container = False
+    try:
+        kids = operator.children
+        if kids:
+            is_container = True
+            children = []
+            for child in sorted(kids, key=lambda c: c.name):
+                child_data = serialize_op(child, depth + 1)
+                if child_data:
+                    children.append(child_data)
+            if children:
+                node['children'] = children
+    except:
+        pass
+
+    # Filtering logic:
+    # - If no filters are active, include everything (original behavior)
+    # - Containers are included only if they have matching children
+    # - Leaf ops are included only if they pass all filters
+    if has_active_filters():
+        if is_container:
+            if 'children' not in node or not node['children']:
+                # Container with no matching descendants -- check if it matches on its own
+                if not matches_filters(operator):
+                    return None
+        else:
+            if not matches_filters(operator):
+                return None
+
+    return node
+
+
+# ─── Main ──────────────────────────────────────────────────────────────
+
+def export_network(root_path='/', output_filename='network_export.json',
+                   families=None, types=None, path_prefix=None,
+                   max_depth=None, include_patterns=None,
+                   exclude_patterns=None):
+    """Export the operator network to JSON with optional filtering.
+
+    Can be called as a function for programmatic use, or the script
+    can be run directly with the module-level configuration variables.
+
+    Args:
+        root_path: Starting operator path (default: '/')
+        output_filename: Output filename in project folder
+        families: List of operator families, e.g. ['TOP', 'CHOP']
+        types: List of operator types, e.g. ['moviefilein', 'null']
+        path_prefix: Only export ops under this path
+        max_depth: Max recursion depth (default: 6)
+        include_patterns: fnmatch patterns for operator names to include
+        exclude_patterns: fnmatch patterns for operator names to exclude
+
+    Returns:
+        The serialized data dict.
+    """
+    global FILTER_FAMILIES, FILTER_TYPES, FILTER_PATH_PREFIX
+    global FILTER_MAX_DEPTH, INCLUDE_PATTERNS, EXCLUDE_PATTERNS
+
+    if families is not None:
+        FILTER_FAMILIES = families
+    if types is not None:
+        FILTER_TYPES = types
+    if path_prefix is not None:
+        FILTER_PATH_PREFIX = path_prefix
+    if max_depth is not None:
+        FILTER_MAX_DEPTH = max_depth
+    if include_patterns is not None:
+        INCLUDE_PATTERNS = include_patterns
+    if exclude_patterns is not None:
+        EXCLUDE_PATTERNS = exclude_patterns
+
+    root = op(root_path)
+    data = serialize_op(root)
+
+    output_path = project.folder + '/' + output_filename
+    with open(output_path, 'w') as f:
+        json.dump(data, f, indent=2, default=str)
+
+    active = []
+    if FILTER_FAMILIES:
+        active.append('families=' + str(FILTER_FAMILIES))
+    if FILTER_TYPES:
+        active.append('types=' + str(FILTER_TYPES))
+    if FILTER_PATH_PREFIX:
+        active.append('path_prefix=' + FILTER_PATH_PREFIX)
+    if INCLUDE_PATTERNS:
+        active.append('include=' + str(INCLUDE_PATTERNS))
+    if EXCLUDE_PATTERNS:
+        active.append('exclude=' + str(EXCLUDE_PATTERNS))
+    active.append('max_depth=' + str(FILTER_MAX_DEPTH))
+
+    size_kb = len(json.dumps(data, default=str)) / 1024
+    print(f"Exported network to: {output_path}")
+    print(f"Total JSON size: {size_kb:.0f} KB")
+    if active:
+        print(f"Active filters: {', '.join(active)}")
+
+    return data
+
+
+# When run directly (exec from Text DAT), use module-level config
 root = op('/')
-data = serialize_op(root, max_depth=6)
+data = serialize_op(root)
 
-# Write to file
 output_path = project.folder + '/network_export.json'
 with open(output_path, 'w') as f:
-	json.dump(data, f, indent=2, default=str)
+    json.dump(data, f, indent=2, default=str)
 
 print(f"Exported network to: {output_path}")
 print(f"Total JSON size: {len(json.dumps(data, default=str)) / 1024:.0f} KB")
+if has_active_filters():
+    filters = []
+    if FILTER_FAMILIES:
+        filters.append(f"families={FILTER_FAMILIES}")
+    if FILTER_TYPES:
+        filters.append(f"types={FILTER_TYPES}")
+    if FILTER_PATH_PREFIX:
+        filters.append(f"path_prefix={FILTER_PATH_PREFIX}")
+    if INCLUDE_PATTERNS:
+        filters.append(f"include={INCLUDE_PATTERNS}")
+    if EXCLUDE_PATTERNS:
+        filters.append(f"exclude={EXCLUDE_PATTERNS}")
+    print(f"Active filters: {', '.join(filters)}")


### PR DESCRIPTION
## Summary

- Adds configurable filters to `export_network.py`: operator family, type, path prefix, depth, and name patterns (fnmatch include/exclude)
- Filters combine with AND logic; all are optional (set to `None` to disable)
- Container COMPs are preserved when they have matching descendants, keeping hierarchy intact
- Also exposes `export_network()` as a callable function for programmatic use from other DATs
- README updated with filtering docs and usage examples

Closes #1

## Test plan

- [ ] Run unfiltered export in TD, verify output matches original behavior
- [ ] Set `FILTER_FAMILIES = ['TOP']` and verify only TOPs (and their parent containers) appear
- [ ] Set `FILTER_PATH_PREFIX` to a known subtree path, verify only that subtree exports
- [ ] Set `EXCLUDE_PATTERNS = ['local*']` and verify matching ops are omitted
- [ ] Combine multiple filters and verify AND logic
- [ ] Call `export_network()` programmatically from Textport with kwargs

🤖 Generated with [Claude Code](https://claude.com/claude-code)