### PR TITLE
Rename script and fix review edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Turn your export into a markdown overview that Claude Code (or any LLM) can use 
 
 ```bash
 # Generate TD_NETWORK.md (default output)
-python generate_claude_md.py network_export.json
+python generate_network_summary.py network_export.json
 
 # Also add a reference in CLAUDE.md so Claude Code picks it up
-python generate_claude_md.py network_export.json --update-claude-md
+python generate_network_summary.py network_export.json --update-claude-md
 ```
 
 This writes `TD_NETWORK.md` with the operator tree, signal flows, key parameters, and family reference. The `--update-claude-md` flag adds a one-liner to your `CLAUDE.md` pointing to it.
@@ -56,19 +56,19 @@ This writes `TD_NETWORK.md` with the operator tree, signal flows, key parameters
 
 ```bash
 # Print to stdout instead of a file
-python generate_claude_md.py network_export.json --stdout
+python generate_network_summary.py network_export.json --stdout
 
 # Custom output path
-python generate_claude_md.py network_export.json -o my_network.md
+python generate_network_summary.py network_export.json -o my_network.md
 
 # Control tree depth (default: 3 levels)
-python generate_claude_md.py network_export.json --tree-depth 4
+python generate_network_summary.py network_export.json --tree-depth 4
 
 # Limit parameter entries (default: 20)
-python generate_claude_md.py network_export.json --max-params 10
+python generate_network_summary.py network_export.json --max-params 10
 
 # Use a custom template
-python generate_claude_md.py network_export.json --template my_template.md
+python generate_network_summary.py network_export.json --template my_template.md
 ```
 
 ### Custom Templates
@@ -85,7 +85,7 @@ Create a markdown file with these placeholders:
 ### Programmatic Usage
 
 ```python
-from generate_claude_md import generate, update_claude_md
+from generate_network_summary import generate, update_claude_md
 
 md = generate('network_export.json', tree_depth=4, max_params=10)
 with open('TD_NETWORK.md', 'w') as f:
@@ -98,7 +98,7 @@ update_claude_md()
 ## Requirements
 
 - TouchDesigner (tested on 2023.x+) for `export_network.py`
-- Python 3.6+ for `generate_claude_md.py` (no external dependencies)
+- Python 3.6+ for `generate_network_summary.py` (no external dependencies)
 
 ## License
 

--- a/generate_network_summary.py
+++ b/generate_network_summary.py
@@ -9,11 +9,11 @@ Default output is TD_NETWORK.md. Use --update-claude-md to also add
 a reference line to CLAUDE.md so Claude Code picks it up automatically.
 
 Usage:
-    python generate_claude_md.py network_export.json
-    python generate_claude_md.py network_export.json -o TD_NETWORK.md
-    python generate_claude_md.py network_export.json --update-claude-md
-    python generate_claude_md.py network_export.json --template my_template.md
-    python generate_claude_md.py network_export.json --tree-depth 4 --max-params 10
+    python generate_network_summary.py network_export.json
+    python generate_network_summary.py network_export.json -o TD_NETWORK.md
+    python generate_network_summary.py network_export.json --update-claude-md
+    python generate_network_summary.py network_export.json --template my_template.md
+    python generate_network_summary.py network_export.json --tree-depth 4 --max-params 10
 """
 
 import json
@@ -54,11 +54,11 @@ def _load_jsonl(path):
     if not ops:
         return {}
 
-    # Build lookup by path
-    by_path = {op['path']: op for op in ops}
+    # Build lookup by path (skip entries missing a path key)
+    by_path = {op['path']: op for op in ops if 'path' in op}
 
     # Reconstruct parent-child relationships from paths
-    for op in ops:
+    for op in by_path.values():
         op_path = op['path']
         parent_path = op_path.rsplit('/', 1)[0] or '/'
         if parent_path != op_path and parent_path in by_path:
@@ -282,7 +282,7 @@ def _render_node(node, lines, max_depth, depth, indent):
 
     # Show inputs if any
     if inputs:
-        input_names = [p.rsplit('/', 1)[-1] for p in inputs]
+        input_names = [p.rstrip('/').rsplit('/', 1)[-1] or p for p in inputs]
         label += f"  <- {', '.join(input_names)}"
 
     lines.append(f"{prefix}{label}")

--- a/generate_network_summary.py
+++ b/generate_network_summary.py
@@ -68,7 +68,7 @@ def _load_jsonl(path):
     # Root is the entry with path '/' or the shallowest path
     root = by_path.get('/')
     if not root:
-        root = min(ops, key=lambda o: o['path'].count('/'))
+        root = min(by_path.values(), key=lambda o: o['path'].count('/'))
 
     return _normalize_node(root)
 


### PR DESCRIPTION
## Summary

Addresses non-blocking feedback from PR #8 review:

- Rename `generate_claude_md.py` -> `generate_network_summary.py` (old name was misleading since output is `TD_NETWORK.md`, not `CLAUDE.md`)
- Guard against JSONL entries missing `path` key (skips malformed entries instead of KeyError)
- Fix input path rendering edge case for paths ending with `/`

## Test plan

- [x] Renamed script runs correctly against example_export.json
- [x] README references updated to new filename
- [x] Docstring usage examples updated

Generated with [Claude Code](https://claude.com/claude-code)